### PR TITLE
Chore - add css3 cursor features to ignored list of unsupported browser plugin

### DIFF
--- a/packages/aquila-stylelint/index.js
+++ b/packages/aquila-stylelint/index.js
@@ -244,7 +244,9 @@ module.exports = {
             ],
             "ignore": [
                 "css-nesting",
-                "css3-cursors-newer"
+                "css3-cursors-newer",
+                "css3-cursors",
+                "css3-cursors-grab"
             ]
         }],
         "property-no-vendor-prefix": true,

--- a/packages/aquila-stylelint/package.json
+++ b/packages/aquila-stylelint/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aquila-learning/aquila-stylelint",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "Aquila stylelint",
     "main": "index.js",
     "scripts": {

--- a/packages/aquila-stylelint/package.json
+++ b/packages/aquila-stylelint/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aquila-learning/aquila-stylelint",
-    "version": "1.1.2",
+    "version": "2.0.0",
     "description": "Aquila stylelint",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
- Corrected the package version and will need to deprecate the previous versions from upgrading stylelint as it had breaking changes.