### PR TITLE
disable `jsdoc/require-returns-type` rule

### DIFF
--- a/packages/eslint-config/.eslintrc.json
+++ b/packages/eslint-config/.eslintrc.json
@@ -196,7 +196,7 @@
         "jsdoc/check-types": 1,
         "jsdoc/require-param": 1,
         "jsdoc/require-returns": 1,
-        "jsdoc/require-returns-type": 1,
+        "jsdoc/require-returns-type": 0,
         "jsdoc/valid-types": 1,
         "key-spacing": [
             "error",


### PR DESCRIPTION
This rule constantly gets in the way and with TypeScript it's rarely useful