### PR TITLE
chore: turn off `objectLiteralTypeAssertions` restriction

### DIFF
--- a/packages/eslint-config/.eslintrc.json
+++ b/packages/eslint-config/.eslintrc.json
@@ -48,8 +48,7 @@
         "@typescript-eslint/consistent-type-assertions": [
             "error",
             {
-                "assertionStyle": "as",
-                "objectLiteralTypeAssertions": "never"
+                "assertionStyle": "as"
             }
         ],
         "@typescript-eslint/consistent-type-imports": [


### PR DESCRIPTION
This prevents us from doing

```
{
    foo: { /* ... */ } as Something
}
```

We need to use this pattern a lot, e.g. when casting Storybook args. Currently the only workaround is to do `as unknown as Something` which obviously sidesteps type safety entirely and is not a good approach.